### PR TITLE
Add netstandard2.0 as a target for the .NET SDK

### DIFF
--- a/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
+++ b/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
@@ -25,7 +25,7 @@ public class FeatureBoardClientTests : SdkTestsBase
   public void ItReturnsTheDefaultValueWhenNoValueIsFound()
   {
     var featureBoardMock = Services.Resolve<Mock<IFeatureBoardState>>();
-    featureBoardMock.Setup(x => x.GetSnapshot()).Returns(new FeatureBoardStateSnapshot(Array.Empty<KeyValuePair<string, FeatureConfiguration>>()));
+    featureBoardMock.Setup(x => x.GetSnapshot()).Returns(new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>(0)));
 
     var client = Services.Resolve<IFeatureBoardClient<TestFeatures>>();
 

--- a/libs/dotnet-sdk/Extensions/MathExtensions.cs
+++ b/libs/dotnet-sdk/Extensions/MathExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureBoard.DotnetSdk.Extensions
+{
+  internal static class Math
+  {
+    public static T Max<T>(T first, T second) => Comparer<T>.Default.Compare(first, second) > 0 ? first : second;
+
+    public static T Min<T>(T first, T second) => Comparer<T>.Default.Compare(first, second) < 0 ? first : second;
+  }
+}

--- a/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
+++ b/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
@@ -1,21 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.*" />
+    <PackageReference Include="System.Text.Json" Version="7.*" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/libs/dotnet-sdk/FeatureBoardClient.cs
+++ b/libs/dotnet-sdk/FeatureBoardClient.cs
@@ -3,8 +3,10 @@ using FeatureBoard.DotnetSdk.Helpers;
 using FeatureBoard.DotnetSdk.Models;
 using FeatureBoard.DotnetSdk.State;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.Json.Nodes;
 
 namespace FeatureBoard.DotnetSdk;
 
@@ -12,7 +14,7 @@ public class FeatureBoardClient<TFeatures> : IFeatureBoardClient<TFeatures> wher
 {
   private readonly FeatureBoardStateSnapshot _state;
   private readonly IAudienceProvider _audienceProvider;
-  private readonly ILogger<FeatureBoardClient<TFeatures>> _logger;
+  private readonly ILogger _logger;
 
   public FeatureBoardClient(IFeatureBoardState state, IAudienceProvider audienceProvider, ILogger<FeatureBoardClient<TFeatures>> logger)
   {
@@ -21,52 +23,91 @@ public class FeatureBoardClient<TFeatures> : IFeatureBoardClient<TFeatures> wher
     _state = state.GetSnapshot();
   }
 
-  public TProp GetFeatureValue<TProp>(Expression<Func<TFeatures, TProp>> expr, TProp defaultValue)
+  public decimal GetFeatureValue(Expression<Func<TFeatures, decimal>> expr, decimal defaultValue)
+    => GetFeatureValue(expr, defaultValue, GetFeatureValue);
+
+  public decimal GetFeatureValue(string featureKey, decimal defaultValue)
+    => GetFeatureValue(featureKey, defaultValue, JsonTryGetValue);
+
+
+  public bool GetFeatureValue(Expression<Func<TFeatures, bool>> expr, bool defaultValue)
+    => GetFeatureValue(expr, defaultValue, GetFeatureValue);
+
+  public bool GetFeatureValue(string featureKey, bool defaultValue)
+    => GetFeatureValue(featureKey, defaultValue, JsonTryGetValue);
+
+
+  public TProp GetFeatureValue<TProp>(Expression<Func<TFeatures, TProp>> expr, TProp defaultValue) where TProp : struct, Enum
+    => GetFeatureValue(expr, defaultValue, GetFeatureValue);
+
+  public TEnum GetFeatureValue<TEnum>(string featureKey, TEnum defaultValue) where TEnum : struct, Enum
+  => GetFeatureValue<TEnum>(featureKey, defaultValue, EnumTryParse);
+
+
+  public string GetFeatureValue(Expression<Func<TFeatures, string>> expr, string defaultValue)
+    => GetFeatureValue(expr, defaultValue, GetFeatureValue);
+
+  public string GetFeatureValue(string featureKey, string defaultValue)
+  {
+    var featureJsonValue = GetFeatureConfigurationValue(featureKey, defaultValue);
+
+    return featureJsonValue?.GetValue<string>() ?? defaultValue;
+  }
+
+
+  private T GetFeatureValue<T>(string featureKey, T defaultValue, FeatureValueParser<T> valueParser)
+  {
+    var featureJsonValue = GetFeatureConfigurationValue(featureKey, defaultValue?.ToString());
+    if (featureJsonValue == null)
+      return defaultValue;
+
+    if (valueParser(featureJsonValue, out T value))
+      return value;
+
+    _logger.LogError("The unable to decode the value to the expected type: {{computedValue: {computedValue}, value: {expectedType}}}", featureJsonValue, typeof(T).Name);
+    return defaultValue;
+  }
+
+
+  private static TProp GetFeatureValue<TProp>(Expression<Func<TFeatures, TProp>> expr, TProp defaultValue, Func<string, TProp, TProp> FeatureValueGetter)
   {
     if (expr.Body is not MemberExpression memberExpression)
-      throw new ArgumentException($"The provided expression contains a {expr.GetType().Name} which is not supported. Only simple member accessors (fields, properties) of an object are supported.");
-
+      throw new ArgumentException($"The provided expression contains a {expr.GetType().Name} which is not supported. Only simple member accessors (fields, properties) of an object are supported.", nameof(expr));
 
     var attr = memberExpression.Member.GetCustomAttribute<FeatureKeyNameAttribute>(); //Caching this value offers no performance improvement
-    return GetFeatureValue(
+    return FeatureValueGetter(
       attr?.Name
         ?? memberExpression.Member.Name.ToFeatureBoardKey(), //Pascal to Kebab case
       defaultValue);
   }
 
-  public TProp GetFeatureValue<TProp>(string featureKey, TProp defaultValue)
+
+  private JsonValue? GetFeatureConfigurationValue(string featureKey, string? defaultValue)
   {
     var feature = _state.Get(featureKey);
     var audienceKeys = _audienceProvider.AudienceKeys;
     if (feature == null)
     {
       _logger.LogDebug("GetFeatureValue - no value, returning user fallback: {defaultValue}", defaultValue);
-      return defaultValue;
+      return null;
     }
 
     var audienceException = feature.AudienceExceptions.FirstOrDefault(a =>
       audienceKeys.Contains(a.AudienceKey)
     );
 
-    if (typeof(TProp).IsEnum)
-    {
-      if (!(audienceException?.Value ?? feature.DefaultValue).TryGetValue<string>(out var strValue) || !Enum.TryParse(typeof(TProp), strValue, true, out var enumValue))
-      {
-        _logger.LogError("The unable to decode the value to the expected type:  {{audienceExceptionValue: {audienceExceptionValue}, defaultValue: {defaultValue}, value: {expectedType}}}", audienceException?.Value, feature.DefaultValue, typeof(TProp).Name);
-        return defaultValue;
-      }
+    var value = audienceException?.Value ?? feature.DefaultValue;
 
-      return enumValue != null ? (TProp)enumValue : defaultValue;
-    }
-
-    if (!(audienceException?.Value ?? feature.DefaultValue).TryGetValue<TProp>(out var value))
-    {
-      _logger.LogError("The unable to decode the value to the expected type:  {{audienceExceptionValue: {audienceExceptionValue}, defaultValue: {defaultValue}, value: {expectedType}}}", audienceException?.Value, feature.DefaultValue, typeof(TProp).Name);
-      return defaultValue;
-    }
-
-    _logger.LogDebug("GetFeatureValue: {{audienceExceptionValue: {audienceExceptionValue}, defaultValue: {defaultValue}, value: {value}}}", audienceException?.Value, feature.DefaultValue, value);
+    _logger.LogDebug("GetFeatureConfigurationValue: {{audienceExceptionValue: {audienceExceptionValue}, defaultValue: {defaultValue}, value: {value}}}", audienceException?.Value, feature.DefaultValue, value);
     return value;
   }
+
+  private delegate bool FeatureValueParser<T>(JsonValue inValue, out T value);
+
+  private static bool JsonTryGetValue<T>(JsonValue jsonValue, out T value) where T : struct
+    => jsonValue.TryGetValue(out value);
+
+  private static bool EnumTryParse<T>(JsonValue jsonValue, out T value) where T : struct, Enum
+    => Enum.TryParse(jsonValue.GetValue<string>(), ignoreCase: true, out value);
 
 }

--- a/libs/dotnet-sdk/FeatureBoardHttpClient.cs
+++ b/libs/dotnet-sdk/FeatureBoardHttpClient.cs
@@ -1,7 +1,6 @@
 using FeatureBoard.DotnetSdk.Models;
 using Microsoft.Extensions.Logging;
 using System.Net;
-using System.Net.Http.Json;
 
 namespace FeatureBoard.DotnetSdk;
 
@@ -31,7 +30,7 @@ internal class FeatureBoardHttpClient : IFeatureBoardHttpClient
 
     if (response.IsSuccessStatusCode)
     {
-      var features = await response.Content.ReadFromJsonAsync<List<FeatureConfiguration>>(cancellationToken: cancellationToken)
+      var features = await response.Content.ReadAsAsync<List<FeatureConfiguration>>(cancellationToken: cancellationToken)
                      ?? throw new ApplicationException("Unable to retrieve decode response content");
 
       lastModified = response.Content.Headers.LastModified ?? lastModified; // if didn't get last-modified header just report previous last modified
@@ -40,7 +39,7 @@ internal class FeatureBoardHttpClient : IFeatureBoardHttpClient
       return (features, lastModified);
     }
 
-    _logger.LogError("Failed to get latest toggles: Service returned error {statusCode}({responseBody})", response.StatusCode, await response.Content.ReadAsStringAsync(cancellationToken));
+    _logger.LogError("Failed to get latest toggles: Service returned error {statusCode}({responseBody})", response.StatusCode, await response.Content.ReadAsStringAsync());
     return (null, lastModified);
   }
 }

--- a/libs/dotnet-sdk/IFeatureBoardClient.cs
+++ b/libs/dotnet-sdk/IFeatureBoardClient.cs
@@ -5,10 +5,22 @@ namespace FeatureBoard.DotnetSdk;
 
 public interface IFeatureBoardClient<TFeatures> : IFeatureBoardClient where TFeatures : IFeatures
 {
-  TProp GetFeatureValue<TProp>(Expression<Func<TFeatures, TProp>> func, TProp defaultValue);
+  bool GetFeatureValue(Expression<Func<TFeatures, bool>> expr, bool defaultValue);
+
+  decimal GetFeatureValue(Expression<Func<TFeatures, decimal>> expr, decimal defaultValue);
+
+  string GetFeatureValue(Expression<Func<TFeatures, string>> expr, string defaultValue);
+
+  TProp GetFeatureValue<TProp>(Expression<Func<TFeatures, TProp>> func, TProp defaultValue) where TProp : struct, Enum;
 }
 
 public interface IFeatureBoardClient
 {
-  internal TProp GetFeatureValue<TProp>(string featureKey, TProp defaultValue);
+  internal bool GetFeatureValue(string featureKey, bool defaultValue);
+
+  internal decimal GetFeatureValue(string featureKey, decimal defaultValue);
+
+  internal string GetFeatureValue(string featureKey, string defaultValue);
+
+  internal TProp GetFeatureValue<TProp>(string featureKey, TProp defaultValue) where TProp : struct, Enum;
 }

--- a/libs/dotnet-sdk/IsExternalInit.cs
+++ b/libs/dotnet-sdk/IsExternalInit.cs
@@ -1,0 +1,12 @@
+// Copied from https://github.com/dotnet/aspnetcore/blob/cf12d968eeaba87c9ebbd53e9420f3b016b0ff21/src/Shared/IsExternalInit.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+// this class is needed for init properties.
+// It was added to .NET 5.0 but for earlier versions we need to specify it manually
+internal static class IsExternalInit { }
+#endif

--- a/libs/dotnet-sdk/State/FeatureBoardStateSnapshot.cs
+++ b/libs/dotnet-sdk/State/FeatureBoardStateSnapshot.cs
@@ -6,7 +6,7 @@ public class FeatureBoardStateSnapshot
 {
   private readonly Dictionary<string, FeatureConfiguration> _snapshot;
 
-  public FeatureBoardStateSnapshot(IEnumerable<KeyValuePair<string, FeatureConfiguration>> state)
+  public FeatureBoardStateSnapshot(IDictionary<string, FeatureConfiguration> state)
   {
     _snapshot = new Dictionary<string, FeatureConfiguration>(state, StringComparer.OrdinalIgnoreCase);
   }


### PR DESCRIPTION
- Rework `FeatureBoardClient` to solve unsupported `Enum.TryParse` overload (+ enforce compile time checking of supported feature value types)
- Add *approximation* of `PeriodicTimer` (which only exists net6.0+)
-  Add `IsExternalInit` stub to enable Init properties to be used < net5.0
- Other misc minor changes for compatibility