### PR TITLE
Revert change to method used to deserialise response from FeatureBoard

### DIFF
--- a/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
+++ b/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.*" />
     <PackageReference Include="System.Text.Json" Version="7.*" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.*" />

--- a/libs/dotnet-sdk/FeatureBoardClient.cs
+++ b/libs/dotnet-sdk/FeatureBoardClient.cs
@@ -3,7 +3,6 @@ using FeatureBoard.DotnetSdk.Helpers;
 using FeatureBoard.DotnetSdk.Models;
 using FeatureBoard.DotnetSdk.State;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json.Nodes;

--- a/libs/dotnet-sdk/FeatureBoardHttpClient.cs
+++ b/libs/dotnet-sdk/FeatureBoardHttpClient.cs
@@ -1,6 +1,7 @@
 using FeatureBoard.DotnetSdk.Models;
 using Microsoft.Extensions.Logging;
 using System.Net;
+using System.Net.Http.Json;
 
 namespace FeatureBoard.DotnetSdk;
 
@@ -30,7 +31,7 @@ internal class FeatureBoardHttpClient : IFeatureBoardHttpClient
 
     if (response.IsSuccessStatusCode)
     {
-      var features = await response.Content.ReadAsAsync<List<FeatureConfiguration>>(cancellationToken: cancellationToken)
+      var features = await response.Content.ReadFromJsonAsync<List<FeatureConfiguration>>(cancellationToken: cancellationToken)
                      ?? throw new ApplicationException("Unable to retrieve decode response content");
 
       lastModified = response.Content.Headers.LastModified ?? lastModified; // if didn't get last-modified header just report previous last modified


### PR DESCRIPTION
Revert change to method used to deserialise response from FeatureBoard API as it uses `Newtonsoft.Json` under the hood