### PR TITLE
Create a manual client for featureboard

### DIFF
--- a/.changeset/fair-ducks-enjoy.md
+++ b/.changeset/fair-ducks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@featureboard/js-sdk': minor
+---
+
+Add manual client which can be used to easily provide static feature values

--- a/libs/js-sdk/src/create-client.ts
+++ b/libs/js-sdk/src/create-client.ts
@@ -1,0 +1,64 @@
+import { EffectiveFeatureValue } from '@featureboard/contracts'
+import { EffectiveFeatureStateStore } from './effective-feature-state-store'
+import { FeatureBoardClient } from './features-client'
+import { debugLog } from './log'
+
+/** Designed for internal SDK use */
+export function createClientInternal(
+    stateStore: EffectiveFeatureStateStore,
+): FeatureBoardClient {
+    return {
+        getEffectiveValues() {
+            const all = stateStore.all()
+            return {
+                audiences: [...stateStore.audiences],
+                effectiveValues: Object.keys(all)
+                    .filter((key) => all[key])
+                    .map<EffectiveFeatureValue>((key) => ({
+                        featureKey: key,
+                        value: all[key]!,
+                    })),
+            }
+        },
+        getFeatureValue: (featureKey, defaultValue) => {
+            const value = stateStore.get(featureKey as string)
+            debugLog('getFeatureValue: %o', {
+                featureKey,
+                value,
+                defaultValue,
+            })
+
+            return value ?? defaultValue
+        },
+        subscribeToFeatureValue(
+            featureKey: string,
+            defaultValue: any,
+            onValue: (value: any) => void,
+        ) {
+            debugLog('subscribeToFeatureValue: %s', featureKey)
+
+            const callback = (updatedFeatureKey: string, value: any): void => {
+                if (featureKey === updatedFeatureKey) {
+                    debugLog(
+                        'subscribeToFeatureValue: %s update: %o',
+                        featureKey,
+                        {
+                            featureKey,
+                            value,
+                            defaultValue,
+                        },
+                    )
+                    onValue(value ?? defaultValue)
+                }
+            }
+
+            stateStore.on('feature-updated', callback)
+            onValue((stateStore.get(featureKey) as any) ?? defaultValue)
+
+            return () => {
+                debugLog('unsubscribeToFeatureValue: %s', featureKey)
+                stateStore.off('feature-updated', callback)
+            }
+        },
+    }
+}

--- a/libs/js-sdk/src/create-manual-client.ts
+++ b/libs/js-sdk/src/create-manual-client.ts
@@ -1,0 +1,42 @@
+import { EffectiveFeatureValue } from '@featureboard/contracts'
+import { Features } from '.'
+import { createClientInternal } from './create-client'
+import { EffectiveFeatureStateStore } from './effective-feature-state-store'
+import { FeatureBoardClient } from './features-client'
+
+/**
+ * Creates a FeatureBoard client which can be used to manually set feature values rather than using the FeatureBoard service
+ */
+export function createManualClient(initialState: {
+    audiences: string[]
+    values: {
+        [K in keyof Features]: Features[K]
+    }
+}): FeatureBoardClient & {
+    set<T extends keyof Features>(featureKey: T, value: Features[T]): void
+} {
+    const stateStore = new EffectiveFeatureStateStore(
+        initialState.audiences,
+        Object.keys(initialState.values)
+            .map((key) => ({
+                featureKey: key,
+                value: initialState.values[key],
+            }))
+            .filter(
+                (
+                    value,
+                ): value is {
+                    featureKey: string
+                    value: EffectiveFeatureValue['value']
+                } => value.value !== undefined,
+            ),
+    )
+    const client = createClientInternal(stateStore)
+
+    return {
+        ...client,
+        set(featureKey, value) {
+            stateStore.set(featureKey as string, value)
+        },
+    }
+}

--- a/libs/js-sdk/src/effective-feature-state-store.ts
+++ b/libs/js-sdk/src/effective-feature-state-store.ts
@@ -1,7 +1,7 @@
 import { EffectiveFeatureValue } from '@featureboard/contracts'
 import { debugLog } from './log'
 
-type FeatureValue = EffectiveFeatureValue['value'] | undefined
+export type FeatureValue = EffectiveFeatureValue['value'] | undefined
 
 const stateStoreDebug = debugLog.extend('state-store')
 
@@ -12,12 +12,9 @@ export class EffectiveFeatureStateStore {
         (featureKey: string, value: FeatureValue) => void
     > = []
 
-    constructor(
-        audiences: string[],
-        initialValues?: EffectiveFeatureValue[],
-    ) {
+    constructor(audiences: string[], initialValues?: EffectiveFeatureValue[]) {
         this._audiences = audiences
-        
+
         for (const value of initialValues || []) {
             this._store[value.featureKey] = value.value
         }

--- a/libs/js-sdk/src/features-client.ts
+++ b/libs/js-sdk/src/features-client.ts
@@ -1,5 +1,5 @@
-import { EffectiveFeatureValue } from '@featureboard/contracts'
 import { Features } from '.'
+import { FeatureBoardEffectiveStateJS } from './js-state'
 
 export interface FeatureBoardClient {
     getFeatureValue<T extends keyof Features>(
@@ -18,8 +18,5 @@ export interface FeatureBoardClient {
         onValue: (value: Features[T]) => void,
     ): () => void
 
-    getEffectiveValues(): {
-        audiences: string[]
-        effectiveValues: EffectiveFeatureValue[]
-    }
+    getEffectiveValues(): FeatureBoardEffectiveStateJS
 }

--- a/libs/js-sdk/src/index.ts
+++ b/libs/js-sdk/src/index.ts
@@ -1,9 +1,13 @@
-export * from './client'
-export * from './client-connection'
-export * from './ensure-single'
-export * from './featureboard-api-config'
-export * from './featureboard-service-urls'
-export * from './features-client'
-export * from './utils/retry'
+export { BrowserClient } from './client-connection'
+export { createBrowserClient } from './create-browser-client'
+export { createManualClient } from './create-manual-client'
+export { FeatureBoardApiConfig } from './featureboard-api-config'
+export { FeatureBoardClient } from './features-client'
+
+// TODO We should make these 'internal' and not export them
+// Need to figure out how to do that with the current build setup
+export { createEnsureSingle } from './ensure-single'
+export { featureBoardHostedService } from './featureboard-service-urls'
+export { retry } from './utils/retry'
 
 export interface Features {}

--- a/libs/js-sdk/src/js-state.ts
+++ b/libs/js-sdk/src/js-state.ts
@@ -1,0 +1,7 @@
+import { EffectiveFeatureValue } from '@featureboard/contracts'
+
+/** Plain JavaScript FeatureBoard state representation */
+export interface FeatureBoardEffectiveStateJS {
+    audiences: string[]
+    effectiveValues: EffectiveFeatureValue[]
+}

--- a/libs/js-sdk/src/tests/http-client.spec.ts
+++ b/libs/js-sdk/src/tests/http-client.spec.ts
@@ -2,7 +2,7 @@ import { EffectiveFeatureValue } from '@featureboard/contracts'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { describe, expect, it } from 'vitest'
-import { createBrowserClient } from '../client'
+import { createBrowserClient } from '../create-browser-client'
 import { featureBoardHostedService } from '../featureboard-service-urls'
 
 describe('http client', () => {
@@ -148,7 +148,7 @@ describe('http client', () => {
                         ctx.json(values),
                         ctx.status(200),
                         ctx.set({
-                            'etag': lastModified,
+                            etag: lastModified,
                         }),
                     ),
             ),
@@ -212,7 +212,7 @@ describe('http client', () => {
                             ctx.json(newValues),
                             ctx.status(200),
                             ctx.set({
-                                'etag': newLastModified,
+                                etag: newLastModified,
                             }),
                         )
                     }
@@ -220,7 +220,7 @@ describe('http client', () => {
                         ctx.json(values),
                         ctx.status(200),
                         ctx.set({
-                            'etag': lastModified,
+                            etag: lastModified,
                         }),
                     )
                 },
@@ -256,44 +256,48 @@ describe('http client', () => {
         }
     })
 
-    it('can start with last known good config', async () => {
-        const server = setupServer(
-            rest.get(
-                'https://client.featureboard.app/effective',
-                (_req, res, ctx) => res(ctx.status(500)),
-            ),
-        )
-        server.listen()
-
-        try {
-            const client = createBrowserClient({
-                environmentApiKey: 'env-api-key',
-                api: featureBoardHostedService,
-                audiences: ['audience1'],
-                initialValues: [
-                    {
-                        featureKey: 'my-feature',
-                        value: 'service-default-value',
-                    },
-                ],
-                updateStrategy: { kind: 'manual' },
-            })
-
-            const value = client.client.getFeatureValue(
-                'my-feature',
-                'default-value',
+    it(
+        'can start with last known good config',
+        async () => {
+            const server = setupServer(
+                rest.get(
+                    'https://client.featureboard.app/effective',
+                    (_req, res, ctx) => res(ctx.status(500)),
+                ),
             )
-            expect(client.initialised).toEqual(false)
-            expect(value).toEqual('service-default-value')
-            await expect(async () => {
-                await client.waitForInitialised()
-            }).rejects.toThrowError('500')
-            expect(client.initialised).toEqual(true)
-        } finally {
-            server.resetHandlers()
-            server.close()
-        }
-    }, { timeout: 60000 })
+            server.listen()
+
+            try {
+                const client = createBrowserClient({
+                    environmentApiKey: 'env-api-key',
+                    api: featureBoardHostedService,
+                    audiences: ['audience1'],
+                    initialValues: [
+                        {
+                            featureKey: 'my-feature',
+                            value: 'service-default-value',
+                        },
+                    ],
+                    updateStrategy: { kind: 'manual' },
+                })
+
+                const value = client.client.getFeatureValue(
+                    'my-feature',
+                    'default-value',
+                )
+                expect(client.initialised).toEqual(false)
+                expect(value).toEqual('service-default-value')
+                await expect(async () => {
+                    await client.waitForInitialised()
+                }).rejects.toThrowError('500')
+                expect(client.initialised).toEqual(true)
+            } finally {
+                server.resetHandlers()
+                server.close()
+            }
+        },
+        { timeout: 60000 },
+    )
 
     it('Handles updating audience', async () => {
         const values: EffectiveFeatureValue[] = [
@@ -322,7 +326,7 @@ describe('http client', () => {
                             ctx.json(newValues),
                             ctx.status(200),
                             ctx.set({
-                                'etag': newLastModified,
+                                etag: newLastModified,
                             }),
                         )
                     }
@@ -330,7 +334,7 @@ describe('http client', () => {
                         ctx.json(values),
                         ctx.status(200),
                         ctx.set({
-                            'etag': lastModified,
+                            etag: lastModified,
                         }),
                     )
                 },
@@ -407,7 +411,7 @@ describe('http client', () => {
                             ctx.json(newValues),
                             ctx.status(200),
                             ctx.set({
-                                'etag': newLastModified,
+                                etag: newLastModified,
                             }),
                         )
                     }
@@ -420,7 +424,7 @@ describe('http client', () => {
                         ctx.json(values),
                         ctx.status(200),
                         ctx.set({
-                            'etag': lastModified,
+                            etag: lastModified,
                         }),
                     )
                 },
@@ -496,7 +500,7 @@ describe('http client', () => {
                             ctx.json(newValues),
                             ctx.status(200),
                             ctx.set({
-                                'etag': newLastModified,
+                                etag: newLastModified,
                             }),
                         )
                     }
@@ -504,7 +508,7 @@ describe('http client', () => {
                         ctx.json(values),
                         ctx.status(200),
                         ctx.set({
-                            'etag': lastModified,
+                            etag: lastModified,
                         }),
                     )
                 },

--- a/libs/js-sdk/src/tests/manual-client.spec.ts
+++ b/libs/js-sdk/src/tests/manual-client.spec.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest'
+import { createManualClient } from '../create-manual-client'
+
+it('can be intialised with initial values', () => {
+    const client = createManualClient({
+        audiences: [],
+        values: {
+            foo: 'bar',
+        },
+    })
+
+    expect(client.getFeatureValue('foo', 'default')).toBe('bar')
+})
+
+it('can set value', () => {
+    const client = createManualClient({
+        audiences: [],
+        values: {
+            foo: 'bar',
+        },
+    })
+
+    client.set('foo', 'baz')
+
+    expect(client.getFeatureValue('foo', 'default')).toBe('baz')
+})
+
+declare module '@featureboard/js-sdk' {
+    interface Features {
+        foo: string
+    }
+}

--- a/libs/js-sdk/src/tests/mode-manual.spec.ts
+++ b/libs/js-sdk/src/tests/mode-manual.spec.ts
@@ -2,7 +2,7 @@ import { EffectiveFeatureValue } from '@featureboard/contracts'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { describe, expect, it } from 'vitest'
-import { createBrowserClient } from '../client'
+import { createBrowserClient } from '../create-browser-client'
 
 describe('Manual update mode', () => {
     it('fetches initial values', async () => {

--- a/libs/js-sdk/src/tests/mode-polling.spec.ts
+++ b/libs/js-sdk/src/tests/mode-polling.spec.ts
@@ -2,7 +2,7 @@ import { EffectiveFeatureValue } from '@featureboard/contracts'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createBrowserClient } from '../client'
+import { createBrowserClient } from '../create-browser-client'
 import { interval } from '../interval'
 
 beforeEach(() => {

--- a/libs/node-sdk/src/index.ts
+++ b/libs/node-sdk/src/index.ts
@@ -1,3 +1,8 @@
-export * from './server-client'
-export * from './server-connection'
-export * from './external-state-store'
+export {
+    FeatureBoardApiConfig,
+    FeatureBoardClient,
+    Features,
+} from '@featureboard/js-sdk'
+export { ExternalStateStore } from './external-state-store'
+export { CreateServerClientOptions, createServerClient } from './server-client'
+export { ServerClient } from './server-connection'

--- a/libs/node-sdk/src/server-client.ts
+++ b/libs/node-sdk/src/server-client.ts
@@ -1,3 +1,4 @@
+import { EffectiveFeatureValue } from '@featureboard/contracts'
 import {
     FeatureBoardApiConfig,
     FeatureBoardClient,
@@ -11,7 +12,6 @@ import { AllFeatureStateStore } from './feature-state-store'
 import { debugLog } from './log'
 import { resolveUpdateStrategy } from './update-strategies/resolveUpdateStrategy'
 import { UpdateStrategies } from './update-strategies/update-strategies'
-import { EffectiveFeatureValue } from '@featureboard/contracts'
 
 const serverConnectionDebug = debugLog.extend('server-connection')
 
@@ -32,7 +32,7 @@ export interface CreateServerClientOptions {
      * manual - will not proactively update
      * live - uses websockets for near realtime updates
      * polling - checks with the featureboard service every 30seconds (or configured interval) for updates
-     * on-request - checks for updates on every request - see docs for how to enable HTTP caching in node
+     * on-request - checks for updates on every request
      */
     updateStrategy?: UpdateStrategies | UpdateStrategies['kind']
 
@@ -111,7 +111,7 @@ export function createServerClient({
                 ? addUserWarnings(
                       request.then(() => syncRequest(stateStore, audienceKeys)),
                   )
-                : addSyncUserWarnings(syncRequest(stateStore, audienceKeys))
+                : makeRequestClient(syncRequest(stateStore, audienceKeys))
         },
         updateFeatures() {
             return updateStrategyImplementation.updateFeatures()
@@ -138,8 +138,10 @@ function addUserWarnings(
     return client as any
 }
 
-/** Adds warnings to the promise if the user doesn't await it */
-function addSyncUserWarnings(
+/**
+ * Makes a request client which is can be awaited or not
+ **/
+export function makeRequestClient(
     client: FeatureBoardClient,
 ): FeatureBoardClient & PromiseLike<FeatureBoardClient> {
     return client as any

--- a/libs/node-sdk/src/update-strategies/update-strategies.ts
+++ b/libs/node-sdk/src/update-strategies/update-strategies.ts
@@ -4,7 +4,7 @@
  * manual - will not proactively update
  * live - uses websockets for near realtime updates
  * polling - checks with the featureboard service every 30seconds (or configured interval) for updates
- * on-request - checks for updates on every request - see docs for how to enable HTTP caching in node
+ * on-request - checks for updates on every request
  */
 
 import type { LiveOptions } from '@featureboard/live-connection'


### PR DESCRIPTION
Remix will require us to transfer the values from the server to the client. 

Also I would like to be able to do local development with a static set of features (and soon create dev tools so you can toggle them in the UI).

Without this I'd have to copy/paste a heap of code or open up a bunch of internal functions which I don't want to open up