### PR TITLE
FB-279: Sync FeatureBoard API state back to ExternalState provider if registered

### DIFF
--- a/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
+++ b/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
@@ -18,6 +18,7 @@ public class FeatureBoardClientTests
   public FeatureBoardClientTests()
   {
     Services.AddTransient(typeof(ILogger<>), typeof(NullLogger<>));
+    Services.AddTransient(typeof(Lazy<>));
     Services.AddTransient<FeatureBoardClient<TestFeatures>>();
 
     var audienceMock = Services.AddServiceMock<IAudienceProvider>((_, mock) =>

--- a/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
+++ b/libs/dotnet-sdk-test/FeatureBoardClientTests.cs
@@ -1,13 +1,13 @@
 using System.Text.Json.Nodes;
+using Bogus;
+using FeatureBoard.DotnetSdk.Helpers;
+using FeatureBoard.DotnetSdk.Models;
+using FeatureBoard.DotnetSdk.State;
 using FeatureBoard.DotnetSdk.Test.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Bogus;
 using Shouldly;
-using FeatureBoard.DotnetSdk.Helpers;
-using FeatureBoard.DotnetSdk.Models;
-using FeatureBoard.DotnetSdk.State;
 
 namespace FeatureBoard.DotnetSdk.Test;
 
@@ -30,7 +30,7 @@ public class FeatureBoardClientTests
   [Fact]
   public void ItReturnsTheDefaultValueWhenNoValueIsFound()
   {
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>(0)));
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>(0)));
 
     var client = Services.BuildServiceProvider().GetRequiredService<FeatureBoardClient<TestFeatures>>();
 
@@ -45,7 +45,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultFeatureValue = faker.Lorem.Sentence();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
     {
       {
         nameof(TestFeatures.StringFeature).ToFeatureBoardKey(), new FeatureConfiguration
@@ -67,7 +67,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = faker.Lorem.Paragraph();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
       {
         {
           nameof(TestFeatures.StringFeature).ToFeatureBoardKey(), new FeatureConfiguration
@@ -96,7 +96,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = faker.Random.Decimal();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
       {
         {
           nameof(TestFeatures.NumberFeature).ToFeatureBoardKey(), new FeatureConfiguration
@@ -126,7 +126,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = faker.Random.Bool();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
         {
           nameof(TestFeatures.BoolFeature).ToFeatureBoardKey(), new FeatureConfiguration
           {
@@ -154,7 +154,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = Guid.NewGuid().ToString();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>
       {
         {
           nameof(TestFeatures.StringFeature).ToFeatureBoardKey(), new FeatureConfiguration
@@ -183,7 +183,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = faker.PickRandom<TestEnum>();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
         {
           nameof(TestFeatures.EnumFeature).ToFeatureBoardKey(), new FeatureConfiguration
           {
@@ -212,7 +212,7 @@ public class FeatureBoardClientTests
   {
     var faker = new Faker();
     var defaultAudienceValue = Guid.NewGuid().ToString();
-    Services.AddTransient<FeatureBoardStateSnapshot>(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
+    Services.AddTransient(_ => new FeatureBoardStateSnapshot(new Dictionary<string, FeatureConfiguration>      {
         {
           "a-strange-name", new FeatureConfiguration
           {

--- a/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
+++ b/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.*" />

--- a/libs/dotnet-sdk/FeatureBoardClient.cs
+++ b/libs/dotnet-sdk/FeatureBoardClient.cs
@@ -1,22 +1,21 @@
-using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json.Nodes;
-using Microsoft.Extensions.Logging;
 using FeatureBoard.DotnetSdk.Attributes;
 using FeatureBoard.DotnetSdk.Helpers;
 using FeatureBoard.DotnetSdk.Models;
 using FeatureBoard.DotnetSdk.State;
+using Microsoft.Extensions.Logging;
 
 namespace FeatureBoard.DotnetSdk;
 
 internal class FeatureBoardClient<TFeatures> : IFeatureBoardClient<TFeatures> where TFeatures : class, IFeatures
 {
-  private readonly FeatureBoardStateSnapshot _state;
+  private readonly Lazy<FeatureBoardStateSnapshot> _state;
   private readonly IAudienceProvider _audienceProvider;
   private readonly ILogger _logger;
 
-  public FeatureBoardClient(FeatureBoardStateSnapshot state, IAudienceProvider audienceProvider, ILogger<FeatureBoardClient<TFeatures>> logger)
+  public FeatureBoardClient(Lazy<FeatureBoardStateSnapshot> state, IAudienceProvider audienceProvider, ILogger<FeatureBoardClient<TFeatures>> logger)
   {
     _state = state;
     _audienceProvider = audienceProvider;
@@ -84,7 +83,7 @@ internal class FeatureBoardClient<TFeatures> : IFeatureBoardClient<TFeatures> wh
 
   private JsonValue? GetFeatureConfigurationValue(string featureKey, string? defaultValue)
   {
-    var feature = _state.Get(featureKey);
+    var feature = _state.Value.Get(featureKey);
     if (feature == null)
     {
       _logger.LogDebug("GetFeatureValue - no value, returning user fallback: {defaultValue}", defaultValue);

--- a/libs/dotnet-sdk/Registration/RegisterFeatureBoard.cs
+++ b/libs/dotnet-sdk/Registration/RegisterFeatureBoard.cs
@@ -37,7 +37,7 @@ public static class RegisterFeatureBoard
 
     services.AddSingleton<FeatureBoardState>()
       .AddHostedService(static provider => provider.GetRequiredService<FeatureBoardState>())
-      .AddScoped(static provider => provider.GetRequiredService<FeatureBoardState>().GetSnapshot())
+      .AddScoped(static provider => new Lazy<FeatureBoardStateSnapshot>(provider.GetRequiredService<FeatureBoardState>().GetSnapshot))
       .AddTransient<FeatureConfigurationUpdated>(static provider =>
       {
         var service = provider.GetRequiredService<FeatureBoardState>();

--- a/libs/dotnet-sdk/Registration/RegisterFeatureBoard.cs
+++ b/libs/dotnet-sdk/Registration/RegisterFeatureBoard.cs
@@ -38,15 +38,7 @@ public static class RegisterFeatureBoard
     services.AddSingleton<FeatureBoardState>()
       .AddHostedService(static provider => provider.GetRequiredService<FeatureBoardState>())
       .AddScoped(static provider => new Lazy<FeatureBoardStateSnapshot>(provider.GetRequiredService<FeatureBoardState>().GetSnapshot))
-      .AddTransient<FeatureConfigurationUpdated>(static provider =>
-      {
-        var service = provider.GetRequiredService<FeatureBoardState>();
-        return (config, _) =>
-        {
-          service.Update(config);
-          return Task.CompletedTask;
-        };
-      });
+      .AddTransient<IFeatureBoardStateUpdateHandler, FeatureBoardStateUpdater>();
 
     return new FeatureBoardBuilder(services);
   }
@@ -83,7 +75,7 @@ public static class RegisterFeatureBoard
   public static FeatureBoardBuilder WithExternalState<TStateStore>(this FeatureBoardBuilder builder) where TStateStore : class, IFeatureBoardExternalState
   {
     builder.Services.AddSingleton<IFeatureBoardExternalState, TStateStore>()
-      .AddTransient<FeatureConfigurationUpdated>(static provider => provider.GetRequiredService<FeatureBoard.DotnetSdk.State.IFeatureBoardExternalState>().UpdateState);
+      .AddTransient<IFeatureBoardStateUpdateHandler>(static provider => provider.GetRequiredService<IFeatureBoardExternalState>());
 
     return builder;
   }

--- a/libs/dotnet-sdk/State/FeatureBoardState.cs
+++ b/libs/dotnet-sdk/State/FeatureBoardState.cs
@@ -1,7 +1,6 @@
-using System.Threading;
+using FeatureBoard.DotnetSdk.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using FeatureBoard.DotnetSdk.Models;
 
 namespace FeatureBoard.DotnetSdk.State;
 
@@ -26,12 +25,10 @@ internal sealed class FeatureBoardState : IFeatureBoardState, IHostedService
 
   public async Task StartAsync(CancellationToken cancellationToken)
   {
-    if (_externalState is null)
-    {
-      using var scope = _scopeFactory.CreateScope();
-      await scope.ServiceProvider.GetRequiredService<IFeatureBoardService>().RefreshFeatureConfiguration(cancellationToken);
+    using var scope = _scopeFactory.CreateScope();
+    var updated = await scope.ServiceProvider.GetRequiredService<IFeatureBoardService>().RefreshFeatureConfiguration(cancellationToken) ?? false;
+    if (updated || _externalState is null)
       return;
-    }
 
     var state = await _externalState.GetState(cancellationToken);
     if (state == null)

--- a/libs/dotnet-sdk/State/FeatureBoardState.cs
+++ b/libs/dotnet-sdk/State/FeatureBoardState.cs
@@ -21,7 +21,12 @@ internal sealed class FeatureBoardState : IFeatureBoardState, IHostedService
   public FeatureBoardStateSnapshot GetSnapshot() => new FeatureBoardStateSnapshot(_cache);
 
 
-  public void Update(IReadOnlyCollection<FeatureConfiguration> state) => _cache = state.ToDictionary(s => s.FeatureKey, s => s);
+  /// <summary>
+  /// Update internal cache of feature configuration based on supplied collection
+  /// </summary>
+  /// <param name="state"></param>
+  /// <exception cref="ArgumentException">Thrown if <see cref="FeatureConfiguration.FeatureKey"/> is <c>null</c> or is reused in collection</exception>
+  internal void Update(IReadOnlyCollection<FeatureConfiguration> state) => _cache = state.ToDictionary(s => s.FeatureKey, s => s);
 
   public async Task StartAsync(CancellationToken cancellationToken)
   {

--- a/libs/dotnet-sdk/State/FeatureBoardStateUpdater.cs
+++ b/libs/dotnet-sdk/State/FeatureBoardStateUpdater.cs
@@ -1,0 +1,29 @@
+using FeatureBoard.DotnetSdk.Models;
+
+namespace FeatureBoard.DotnetSdk.State;
+
+/// <summary>
+/// Adapter around FeatureBoardState to allow Update to be called in IFeatureBoardStateUpdateHandler conformant manner
+/// </summary>
+internal class FeatureBoardStateUpdater : IFeatureBoardStateUpdateHandler
+{
+  private readonly FeatureBoardState _state;
+
+  public FeatureBoardStateUpdater(FeatureBoardState state) => _state = state;
+
+  public virtual Task UpdateState(IReadOnlyCollection<FeatureConfiguration> configuration, CancellationToken cancellation)
+  {
+    if (cancellation.IsCancellationRequested)
+      return Task.FromCanceled(cancellation);
+
+    try
+    {
+      _state.Update(configuration);
+      return Task.CompletedTask;
+    }
+    catch (Exception e)
+    {
+      return Task.FromException(e);
+    }
+  }
+}

--- a/libs/dotnet-sdk/State/IFeatureBoardExternalState.cs
+++ b/libs/dotnet-sdk/State/IFeatureBoardExternalState.cs
@@ -2,8 +2,7 @@ using FeatureBoard.DotnetSdk.Models;
 
 namespace FeatureBoard.DotnetSdk.State;
 
-public interface IFeatureBoardExternalState
+public interface IFeatureBoardExternalState : IFeatureBoardStateUpdateHandler
 {
   Task<IReadOnlyCollection<FeatureConfiguration>> GetState(CancellationToken cancellationToken);
-  Task UpdateState(IReadOnlyCollection<FeatureConfiguration> features, CancellationToken cancellationToken);
 }

--- a/libs/dotnet-sdk/State/IFeatureBoardStateUpdateHandler.cs
+++ b/libs/dotnet-sdk/State/IFeatureBoardStateUpdateHandler.cs
@@ -1,4 +1,4 @@
-﻿using FeatureBoard.DotnetSdk.Models;
+using FeatureBoard.DotnetSdk.Models;
 
 namespace FeatureBoard.DotnetSdk.State;
 

--- a/libs/dotnet-sdk/State/IFeatureBoardStateUpdateHandler.cs
+++ b/libs/dotnet-sdk/State/IFeatureBoardStateUpdateHandler.cs
@@ -1,0 +1,8 @@
+﻿using FeatureBoard.DotnetSdk.Models;
+
+namespace FeatureBoard.DotnetSdk.State;
+
+public interface IFeatureBoardStateUpdateHandler
+{
+  Task UpdateState(IReadOnlyCollection<FeatureConfiguration> configuration, CancellationToken cancellation);
+}


### PR DESCRIPTION
Relevant JIRAs: [FB-279](https://arkahna.atlassian.net/browse/FB-279) & [FB-246](https://arkahna.atlassian.net/browse/FB-246)

Summary of changes:
* At Web App host startup, only attempt to load config from external state if fail to retrieve from FB API (FB-246)
* Each time feature config changes (as determined by FB API ETag) write back to external state if registered (FB-279)
* Add retry for 5xx, 408, 429 status code responses and transient network faults when calling FB API
  * Max 5 retries
  * Exponential backoff used unless `Retry-After` header is present in response


[FB-279]: https://arkahna.atlassian.net/browse/FB-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FB-246]: https://arkahna.atlassian.net/browse/FB-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ