### PR TITLE
Find \*.csproj files as long as they are in a parent folder when trying to find a namespace

### DIFF
--- a/apps/cli/src/commands/code-gen.ts
+++ b/apps/cli/src/commands/code-gen.ts
@@ -91,10 +91,10 @@ export function codeGenCommand() {
 
                     options.output = promptResult.output
                 }
-                const outputAbsolutePath = path.join(
-                    process.cwd(),
-                    options.output!,
-                )
+                const outputAbsolutePath = path.isAbsolute(options.output!)
+                    ? options.output!
+                    : path.join(process.cwd(), options.output!)
+
                 try {
                     await fsAsync.access(outputAbsolutePath)
                 } catch {
@@ -129,11 +129,17 @@ export function codeGenCommand() {
                     throw new Error("Organization isn't set")
                 }
 
-                const tree = new FsTree(process.cwd(), options.verbose)
+                const tree = new FsTree(
+                    path.parse(outputAbsolutePath).root,
+                    options.verbose,
+                )
                 await codeGenerator({
                     template: options.template as Template,
                     tree: tree,
-                    relativeFilePath: options.output!,
+                    relativeFilePath: path.relative(
+                        tree.root,
+                        outputAbsolutePath,
+                    ),
                     featureBoardProductName: options.product,
                     auth: bearerToken
                         ? {

--- a/libs/code-generator/src/lib/code-generator.ts
+++ b/libs/code-generator/src/lib/code-generator.ts
@@ -7,7 +7,7 @@ import type {
 import { getProjectFeatures } from './api/get-project-features'
 import { getProjects } from './api/get-projects'
 import {
-    getDotNetNameSpace,
+    getDotNetNamespace,
     toDotNetType,
     toPascalCase,
 } from './generators/dotnet-api/functions'
@@ -45,9 +45,10 @@ export async function codeGenerator(
     const templateSpecificOptions: any = {}
     switch (options.template) {
         case 'dotnet-api':
-            templateSpecificOptions.namespace = getDotNetNameSpace(
+            templateSpecificOptions.namespace = await getDotNetNamespace(
                 options.tree,
                 relativeFilePath,
+                options.interactive,
             )
     }
 

--- a/libs/code-generator/src/lib/generators/dotnet-api/functions.ts
+++ b/libs/code-generator/src/lib/generators/dotnet-api/functions.ts
@@ -53,7 +53,7 @@ export async function getDotNetNamespace(
         const response = await prompts({
             type: 'text',
             name: 'namespace',
-            message: `Please provide your .net namespace.`,
+            message: `Please provide your .net namespace:`,
         })
 
         // handle the 'any'

--- a/libs/code-generator/src/lib/generators/dotnet-api/functions.ts
+++ b/libs/code-generator/src/lib/generators/dotnet-api/functions.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import prompts from 'prompts'
 import type { Tree } from '../../tree/tree'
 
 export function toPascalCase(str: string) {
@@ -25,7 +26,11 @@ export function toDotNetType(feature: any) {
     }
 }
 
-export function getDotNetNameSpace(tree: Tree, filePath: string): string {
+export async function getDotNetNamespace(
+    tree: Tree,
+    filePath: string,
+    interactive: boolean,
+): Promise<string> {
     const files = tree.children(filePath)
     const namespace = files
         .find((x) => x.endsWith('.csproj'))
@@ -34,8 +39,26 @@ export function getDotNetNameSpace(tree: Tree, filePath: string): string {
     if (namespace) return namespace
 
     const parentDir = path.join(filePath, '..')
-    if (parentDir == filePath || parentDir == '.')
-        throw new Error("Can't find .net project file")
 
-    return getDotNetNameSpace(tree, parentDir)
+    if (parentDir == filePath || parentDir == '.') {
+        if (!interactive) {
+            throw new Error(
+                'Unable to locate .NET csproj file under the output folder.',
+            )
+        }
+
+        console.error(
+            'Unable to locate .NET csproj file under the output folder.',
+        )
+        const response = await prompts({
+            type: 'text',
+            name: 'namespace',
+            message: `Please provide your .net namespace.`,
+        })
+
+        // handle the 'any'
+        return `${response.namespace}`
+    }
+
+    return await getDotNetNamespace(tree, parentDir, interactive)
 }


### PR DESCRIPTION
Prompt for a namespace if once can't be resolved
Allow users to specify an absolute path for the output file