### PR TITLE
Centralize code for saving generated files

### DIFF
--- a/.changeset/hungry-hotels-repeat.md
+++ b/.changeset/hungry-hotels-repeat.md
@@ -1,0 +1,5 @@
+---
+'dotnet-sdk': patch
+---
+
+Update deprecated packages

--- a/.changeset/slimy-cats-wait.md
+++ b/.changeset/slimy-cats-wait.md
@@ -1,0 +1,8 @@
+---
+'@featureboard/code-generator': patch
+'@featureboard/nx-plugin': patch
+'@featureboard/cli': patch
+---
+
+Centralize code for saving generated files
+Fix bug where dryrun output method would be shown if there were no changes and verbose was not set

--- a/apps/cli/src/commands/code-gen.ts
+++ b/apps/cli/src/commands/code-gen.ts
@@ -7,8 +7,7 @@ import type { Template } from '@featureboard/code-generator'
 import {
     FsTree,
     codeGenerator,
-    flushChanges,
-    printChanges,
+    saveChanges,
 } from '@featureboard/code-generator'
 import fsAsync from 'fs/promises'
 import path from 'node:path'
@@ -155,24 +154,7 @@ export function codeGenCommand() {
                     apiEndpoint: API_ENDPOINT,
                 })
 
-                const changes = tree.listChanges()
-                if (!options.quiet) {
-                    printChanges(changes)
-                    if (changes.length === 0) {
-                        console.log(
-                            `\nFiles are the same no changes were made.`,
-                        )
-                        return
-                    }
-                }
-
-                if (!options.dryRun && changes.length !== 0) {
-                    flushChanges(tree.root, changes)
-                    return
-                }
-                console.log(
-                    `\nNOTE: The "dryRun" flag means no changes were made.`,
-                )
+                saveChanges(tree, options.dryRun, !options.quiet)
             }),
         )
 }

--- a/libs/code-generator/src/index.ts
+++ b/libs/code-generator/src/index.ts
@@ -6,5 +6,10 @@ export { codeGenerator } from './lib/code-generator'
 export type { CodeGeneratorOptions, Template } from './lib/code-generator'
 export { queryFeatureBoard } from './lib/queryFeatureBoard'
 export type { FeatureBoardAuth } from './lib/queryFeatureBoard'
-export { FsTree, flushChanges, printChanges } from './lib/tree/tree'
+export {
+    FsTree,
+    flushChanges,
+    printChanges,
+    saveChanges,
+} from './lib/tree/tree'
 export type { Tree } from './lib/tree/tree'

--- a/libs/code-generator/src/lib/tree/tree.ts
+++ b/libs/code-generator/src/lib/tree/tree.ts
@@ -425,3 +425,24 @@ export function printChanges(fileChanges: FileChange[], indent = ''): void {
         }
     })
 }
+
+export function saveChanges(tree: Tree, dryRun: boolean, verbose: boolean) {
+    const changes = tree.listChanges()
+    if (verbose) {
+        printChanges(changes)
+    }
+
+    if (changes.length === 0) {
+        if (verbose) {
+            console.log(`\nFiles are the same no changes were made.`)
+        }
+        return
+    }
+
+    if (!dryRun) {
+        flushChanges(tree.root, changes)
+        return
+    }
+
+    console.log(`\nNOTE: The "dryRun" flag means no changes were made.`)
+}

--- a/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
+++ b/libs/dotnet-sdk/FeatureBoard.DotnetSdk.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.*" />
-    <PackageReference Include="System.Text.Json" Version="7.*" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http.Json" Version="7.*" />
   </ItemGroup>
 
@@ -42,8 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
-    <None Include="assets\featureboard-logo.png" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="assets\featureboard-logo.png" Pack="true" PackagePath="\" />
 </ItemGroup>
 
   <PropertyGroup>

--- a/libs/nx-plugin/src/executors/code-gen/executor.ts
+++ b/libs/nx-plugin/src/executors/code-gen/executor.ts
@@ -4,10 +4,11 @@ import {
 } from '@featureboard/api-authentication'
 import {
     codeGenerator,
+    saveChanges,
     type FeatureBoardAuth,
 } from '@featureboard/code-generator'
 import { joinPathFragments, type ExecutorContext, type Tree } from '@nx/devkit'
-import { FsTree, flushChanges, printChanges } from 'nx/src/generators/tree'
+import { FsTree } from 'nx/src/generators/tree'
 import { API_ENDPOINT, CLIENT_ID } from '../../shared/config'
 import type { CodeGenExecutorSchema } from './schema'
 
@@ -66,20 +67,4 @@ export async function codeGenExecutor(
     }
 }
 
-function saveChanges(tree: Tree, dryRun: boolean, verbose: boolean) {
-    const changes = tree.listChanges()
-    if (verbose) {
-        printChanges(changes)
-        if (changes.length === 0) {
-            console.log(`\nFiles are the same no changes were made.`)
-            return
-        }
-    }
-
-    if (!dryRun && changes.length !== 0) {
-        flushChanges(tree.root, changes)
-        return
-    }
-    console.log(`\nNOTE: The "dryRun" flag means no changes were made.`)
-}
 export default codeGenExecutor


### PR DESCRIPTION
Fix bug where dryrun output method would be shown if there were no changes and verbose was not set